### PR TITLE
Fix debug property, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module.exports = {
           backgroundColor: "#004"
         }
       ],
-      stripAnsiColors: true, //default
+      stripAnsiSequences: true, //default
       debug: false //default
     }
   }
@@ -96,6 +96,17 @@ module.exports = {
 ### autoProfile.prompts
 
 This section defines different patterns for parsing prompt components: username, host, path.
+
+Note that `pattern` is a string literal passed to the `RegExp()`
+constructor, so remember to escape backslashes in your regexp. For
+example, if you used a site like [regex101.com](https://regex101.com)
+to verify that your regexp `/\[(\w+):\s*(\w+)\](\s*\$)/` is correct,
+you would double each backslash and write the pattern as:
+
+```
+pattern: '\\[(\\w+):\\s*(\\w+)\\](\\s*\\$)',
+```
+The values for `hostname`, `username`, and `pattern` are indexes into the match array returned by `RegExp#exec`.
 
 For example, define a pattern for MacOS bash default prompt:
 
@@ -133,7 +144,7 @@ See [here](http://ascii-table.com/ansi-escape-sequences-vt-100.php) for more det
 
 ### autoProfile.debug (Default: false)
 
-If enabled, debug informations are written to console
+If enabled, debug information is written to the DevTools console
 
 ## Caveat
 

--- a/config.example
+++ b/config.example
@@ -48,7 +48,8 @@
           backgroundColor: '#004'
         }
       ],
-      stripAnsiSequences: true //default
+      stripAnsiSequences: true, //default
+      debug: false, //default
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -146,6 +146,8 @@ function formatConfiguration(autoProfileConfig) {
   if (!autoProfileConfig || !autoProfileConfig.prompts || !autoProfileConfig.profiles) {
     return formattedConfig;
   }
+  formattedConfig.debug = autoProfileConfig.debug;
+  formattedConfig.stripAnsiSequences = autoProfileConfig.stripAnsiSequences;
   formattedConfig.prompts = autoProfileConfig.prompts;
   const profiles = [];
   autoProfileConfig.profiles.forEach(profile => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-autoprofile",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Extension for Hyper.app to profile term according to shell prompt",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The debug property was not being transferred from the hyper.config.autoProfile object to autoProfile's internal config object. Also the example in the README referred  to stripAnsiColors while the property was actually called stripAnsiSequences in the code. I also added a couple of hopefully helpful hints to the README-- things that had me scratching my head for a while.